### PR TITLE
fix emscripten build by flagging it as a static_linking platform

### DIFF
--- a/libretro/Makefile.libretro
+++ b/libretro/Makefile.libretro
@@ -273,6 +273,7 @@ else ifeq ($(platform), emscripten)
 	TARGET := $(TARGET_NAME)_libretro_emscripten.bc
 	fpic := -fPIC
 	SHARED := -shared -Wl,--version-script=$(CORE_DIR)/link.T -Wl,--no-undefined
+	STATIC_LINKING = 1
 else
 	TARGET :=  $(TARGET_NAME)_libretro.dll
 	CC ?= gcc


### PR DESCRIPTION
This fixes emscripten builds under the newer emsdk 3.1.46.